### PR TITLE
Fixed exa_human_time_diff. ago is appended to this function's return

### DIFF
--- a/content-attachment.php
+++ b/content-attachment.php
@@ -19,7 +19,7 @@
 		<!-- <div class="clearfix"></div> -->
 
 		<div class="entry-summary <?php if(!$full_width) { echo "entry-summary-full"; } ?> <?php if(!has_post_thumbnail()){ echo 'stream-no-thumbnail'; } ?>">
-					<p> <span class="summary-time-stamp"><?php echo exa_human_time_diff(get_the_time('U')) ?> ago &middot; </span><?php echo get_the_excerpt(); ?></p>
+					<p> <span class="summary-time-stamp"><?php echo exa_human_time_diff(get_the_time('U')) ?> &middot; </span><?php echo get_the_excerpt(); ?></p>
 		</div><!-- .entry-summary -->
 
 	</a>

--- a/content-summary-featured.php
+++ b/content-summary-featured.php
@@ -32,7 +32,7 @@
 
 
 	<div class="entry-summary">
-		<p> <span class="summary-time-stamp"><?php echo exa_human_time_diff(get_the_time('U')) ?> ago &middot; </span><?php echo get_the_excerpt(); ?></p>
+		<p> <span class="summary-time-stamp"><?php echo exa_human_time_diff(get_the_time('U')) ?> &middot; </span><?php echo get_the_excerpt(); ?></p>
 	</div><!-- .entry-summary -->
 
 	</a>

--- a/content-summary-fullstream-featured.php
+++ b/content-summary-fullstream-featured.php
@@ -34,7 +34,7 @@
 
 
 	<div class="entry-summary <?php if(!has_post_thumbnail()){ echo 'stream-no-thumbnail'; } ?>">
-		<p> <span class="summary-time-stamp"><?php echo exa_human_time_diff(get_the_time('U')) ?> ago &middot; </span><?php echo get_the_excerpt(); ?></p>
+		<p> <span class="summary-time-stamp"><?php echo exa_human_time_diff(get_the_time('U')) ?> &middot; </span><?php echo get_the_excerpt(); ?></p>
 	</div><!-- .entry-summary -->
 
 	</a>

--- a/content-summary-fullstream.php
+++ b/content-summary-fullstream.php
@@ -29,7 +29,7 @@
 		<!-- <div class="clearfix"></div> -->
 
 		<div class="entry-summary <?php if(!$full_width) { echo "entry-summary-full"; } ?> <?php if(!has_post_thumbnail()){ echo 'stream-no-thumbnail'; } ?>">
-					<p> <span class="summary-time-stamp"><?php echo exa_human_time_diff(get_the_time('U')) ?> ago &middot; </span><?php echo get_the_excerpt(); ?></p>
+					<p> <span class="summary-time-stamp"><?php echo exa_human_time_diff(get_the_time('U')) ?> &middot; </span><?php echo get_the_excerpt(); ?></p>
 		</div><!-- .entry-summary -->
 
 	</a>

--- a/content-summary-instream.php
+++ b/content-summary-instream.php
@@ -28,7 +28,7 @@
 		<!-- <div class="clearfix"></div> -->
 
 		<div class="entry-summary <?php if(!$full_width) { echo "entry-summary-full"; } ?>">
-					<p> <span class="summary-time-stamp"><?php echo exa_human_time_diff(get_the_time('U')) ?> ago &middot; </span><?php echo get_the_excerpt(); ?></p>
+					<p> <span class="summary-time-stamp"><?php echo exa_human_time_diff(get_the_time('U')) ?> &middot; </span><?php echo get_the_excerpt(); ?></p>
 		</div><!-- .entry-summary -->
 
 	</a>

--- a/functions.php
+++ b/functions.php
@@ -300,6 +300,7 @@ add_filter( 'excerpt_length', 'exa_custom_excerpt_length', 999 );
  * @return string A readable representation of the time interval.
  */
 function exa_human_time_diff( $from, $to = '' ) {
+	$since = '';
 	if ( empty( $to ) )
 		$to = current_time( "timestamp" );
 	$diff = (int) abs( $to - $from );
@@ -309,20 +310,23 @@ function exa_human_time_diff( $from, $to = '' ) {
 			$mins = 1;
 		}
 		/* translators: min=minute */
-		$since = sprintf( _n( '%s min', '%s mins', $mins ), $mins );
+		$since = sprintf( _n( '%s min ago', '%s mins ago', $mins ), $mins );
 	} elseif ( ( $diff <= DAY_IN_SECONDS ) && ( $diff > HOUR_IN_SECONDS ) ) {
 		$hours = round( $diff / HOUR_IN_SECONDS );
 		if ( $hours <= 1 ) {
 			$hours = 1;
 		}
-		$since = sprintf( _n( '%s hour', '%s hours', $hours ), $hours );
-	} elseif ( $diff >= DAY_IN_SECONDS ) {
+		$since = sprintf( _n( '%s hour ago', '%s hours ago', $hours ), $hours );
+	} elseif ( $diff >= DAY_IN_SECONDS && $diff < DAY_IN_SECONDS * 7) {
 		$days = round( $diff / DAY_IN_SECONDS );
 		if ( $days <= 1 ) {
 			$days = 1;
 		}
-		$since = sprintf( _n( '%s day', '%s days', $days ), $days );
+		$since = sprintf( _n( '%s day ago', '%s days ago', $days ), $days );
+	} elseif ( $diff >= DAY_IN_SECONDS * 7) {
+		$since = gmdate("M d, Y D", $from);
 	}
+
 	return $since;
 }
 

--- a/index.php
+++ b/index.php
@@ -162,7 +162,7 @@ get_header();
 
 	<?php
 
-		//$beats_info is an array that holds beat names.
+	//$beats_info is an array that holds beat names.
 	$beats = array("news" => "news",
 					"oped" => "opinion",
 					"artsetc" => "artsetc",
@@ -247,7 +247,6 @@ get_header();
 						hrld_html_tag_open("span","",array("summary-time-stamp"));
 							echo " &middot; ";
 							echo exa_human_time_diff(get_the_time('U'));
-							echo " ago";
 						hrld_html_tag_close("span");
 					hrld_html_tag_close("span");
 					hrld_html_tag_open("h4");


### PR DESCRIPTION
and after 7 days, the date of publication is shown instead of the "...ago". "Hardcoded" " ago" has been removed, as exa_human_time_diff handles when to put "ago". Addressing #25 
