### PR TITLE
Cleanup subheads

### DIFF
--- a/content-feature.php
+++ b/content-feature.php
@@ -38,9 +38,9 @@ exa_container('hero');
 					<h1 class="article-title"><?php the_title() ?></h1>
 					
 				
-				<?php if( hrld_has_subhead(get_the_ID()) ) : ?>
+				<?php if( exa_has_subhead(get_the_ID()) ) : ?>
 				
-					<h2 class="article-subhead"><?php hrld_the_subhead(); ?></h2>
+					<h2 class="article-subhead"><?php exa_subhead(); ?></h2>
 				
 				<?php endif; ?>
 

--- a/functions.php
+++ b/functions.php
@@ -896,17 +896,12 @@ add_action('wp_head','exa_twitter_card_tags');
 /**
  * The excerpt to serve to facebook, twitter, google, &c.
  *
- * TODO: Add _hrld_subhead support. These are often more appropriate for the space than
- * 		 the lede.
- *
  * @since 0.1
  * 
  * @see http://wordpress.stackexchange.com/questions/26729/get-excerpt-using-get-the-excerpt-outside-a-loop
- * @author Will Haynes
  */
 function exa_get_meta_excerpt($post_id = null) {
 
-	// Gets post ID
     $the_post = get_post($post_id);
 
     if(!$the_post) {
@@ -915,11 +910,8 @@ function exa_get_meta_excerpt($post_id = null) {
 
     $post_id = $the_post->ID;
 
-    // check if the hrld-setup plugin is active, and use subhead here instead.
-    if( function_exists('hrld_has_subhead') && hrld_has_subhead($post_id) ) {
-    	$the_excerpt = hrld_get_subhead($post_id);
-    	// Make sure it ends in a period, or it looks weird on facebook.
-    	$the_excerpt = rtrim($the_excerpt, '.') . '.';
+    if( exa_has_subhead($post_id) ) {
+    	$the_excerpt = exa_subhead($post_id);
     } else {
     	$the_excerpt = $the_post->post_content; // Gets post_content to be used as a basis for the excerpt
     	$excerpt_length = 35; // Sets excerpt length by word count

--- a/inc/containers/footnotes.php
+++ b/inc/containers/footnotes.php
@@ -89,8 +89,8 @@ if(!$container) {
 
 						<h2 class="headline"><?php the_title(); ?></h2>
 
-						<?php if( hrld_has_subhead(get_the_ID()) ) : ?>
-							<h3 class="subhead"><?php hrld_the_subhead(); ?></h3>
+						<?php if( exa_has_subhead(get_the_ID()) ) : ?>
+							<h3 class="subhead"><?php exa_subhead(); ?></h3>
 						<?php else: ?>
 							<h3 class="subhead"><?php the_excerpt(); ?></h3>
 						<?php endif; ?>

--- a/inc/containers/headline.php
+++ b/inc/containers/headline.php
@@ -27,8 +27,8 @@ $container->default_args(array('center'=>false));
 				
 			<h1 class="title"><?php the_title() ?></h1>
 			
-			<?php if( hrld_has_subhead(get_the_ID()) ) : ?>
-				<h2 class="subhead"><?php hrld_the_subhead(); ?></h2>
+			<?php if( exa_has_subhead(get_the_ID()) ) : ?>
+				<h2 class="subhead"><?php exa_subhead(); ?></h2>
 			<?php endif; ?>
 	
 	</div>

--- a/inc/functions/headlines.php
+++ b/inc/functions/headlines.php
@@ -1,30 +1,44 @@
 <?php 
 /**
+ * Adds subheadline support to Exa
  * 
- * 
- * 
+ * @package Exa
+ * @since v0.3
  */
 
-/** 
- * Get the deck
- */
-function hrld_get_subhead($post = null) {
-	$post = get_post($post);
-	return apply_filters('hrld_the_subhead', get_post_meta($post->ID, '_hrld_subhead', TRUE));
-}
-
-/**
- * Display deck
- */
-function hrld_the_subhead() {
-	echo hrld_get_subhead(get_the_ID());
-}
 
 /**
  * Returns true if the post has a subhead
+ *
+ * @since v0.5
+ * 
+ * @param $post (optional) if empty, the current global $post will be used.
  */
-function hrld_has_subhead($post = null) {
-	return hrld_get_subhead($post);
+function exa_has_subhead($post = null) {
+	return exa_get_subhead($post = null) ? true : false;
+}
+
+/**
+ * Prints the post subhead
+ *
+ * @since v0.5
+ * 
+ * @param $post (optional) if empty, the current global $post will be used.
+ */
+function exa_subhead($post = null) {
+	echo exa_get_subhead($post);
+}
+
+/**
+ * Returns the post subhead
+ *
+ * @since v0.5
+ * 
+ * @param $post (optional) if empty, the current global $post will be used.
+ */
+function exa_get_subhead($post = null) {
+	$post = get_post($post);
+	return apply_filters('exa_subhead', get_post_meta($post->ID, '_hrld_subhead', TRUE));
 }
 
 if (is_admin()) :

--- a/inc/partials/article-brief.php
+++ b/inc/partials/article-brief.php
@@ -1,0 +1,9 @@
+<div class="post-box post-%id%">
+	<?php if(has_post_thumbnail()): ?>
+	<div class="thumbnail">
+		<?php the_post_thumbnail(); ?>
+	</div>
+	<?php endif; ?>
+	<h2><?php the_title(); ?></h2>
+	<h3><?php the_excerpt(); ?></h3>
+</div>


### PR DESCRIPTION
_tl;dr_ Cleaning up subhead functions
## Why

Subhead functions were moved from the hrld setup plugin to Exa and are therefore prefixed with `hrld`. This pull request refactors them and provides a little code cleanup.
